### PR TITLE
Jeet wasnt in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp-autoprefixer": "^2.3.1",
     "gulp-minify-css": "^1.2.0",
     "gulp-rename": "^1.2.2",
-    "gulp-stylus": "^2.0.5"
+    "gulp-stylus": "^2.0.5",
+    "jeet": "6.1.2"
   }
 }


### PR DESCRIPTION
so that we wont have to install jeet manually when we npm install
